### PR TITLE
send txs in batches

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,8 @@ fn seconds_since(dt: DateTime<Utc>) -> i64 {
     Utc::now().signed_duration_since(dt).num_seconds()
 }
 
+const BATCH_SIZE: usize = 128;
+
 fn send_mm_transactions(
     quotes_per_second: u64,
     perp_market_caches: &Vec<PerpMarketCache>,
@@ -197,119 +199,135 @@ fn send_mm_transactions(
     blockhash: Arc<RwLock<Hash>>,
     slot: &AtomicU64,
 ) {
+    let mut transactions = Vec::<_>::with_capacity(BATCH_SIZE);
     // update quotes 2x per second
     for _ in 0..quotes_per_second {
         for c in perp_market_caches.iter() {
-            let offset = rand::random::<i8>() as i64;
-            let spread = rand::random::<u8>() as i64;
-            debug!(
-                "price:{:?} price_quote_lots:{:?} order_base_lots:{:?} offset:{:?} spread:{:?}",
-                c.price, c.price_quote_lots, c.order_base_lots, offset, spread
-            );
+            for _ in 0..BATCH_SIZE {
+                let offset = rand::random::<i8>() as i64;
+                let spread = rand::random::<u8>() as i64;
+                debug!(
+                    "price:{:?} price_quote_lots:{:?} order_base_lots:{:?} offset:{:?} spread:{:?}",
+                    c.price, c.price_quote_lots, c.order_base_lots, offset, spread
+                );
 
-            let cancel_ix: Instruction = serde_json::from_str(
-                &serde_json::to_string(
-                    &cancel_all_perp_orders(
-                        &pk_from_str_like(&c.mango_program_pk),
-                        &pk_from_str_like(&c.mango_group_pk),
-                        &pk_from_str_like(&mango_account_pk),
-                        &(pk_from_str_like(&mango_account_signer.pubkey())),
-                        &(pk_from_str_like(&c.perp_market_pk)),
-                        &c.perp_market.bids,
-                        &c.perp_market.asks,
-                        10,
+                let cancel_ix: Instruction = serde_json::from_str(
+                    &serde_json::to_string(
+                        &cancel_all_perp_orders(
+                            &pk_from_str_like(&c.mango_program_pk),
+                            &pk_from_str_like(&c.mango_group_pk),
+                            &pk_from_str_like(&mango_account_pk),
+                            &(pk_from_str_like(&mango_account_signer.pubkey())),
+                            &(pk_from_str_like(&c.perp_market_pk)),
+                            &c.perp_market.bids,
+                            &c.perp_market.asks,
+                            10,
+                        )
+                        .unwrap(),
                     )
                     .unwrap(),
                 )
-                .unwrap(),
-            )
-            .unwrap();
+                .unwrap();
 
-            let place_bid_ix: Instruction = serde_json::from_str(
-                &serde_json::to_string(
-                    &place_perp_order2(
-                        &pk_from_str_like(&c.mango_program_pk),
-                        &pk_from_str_like(&c.mango_group_pk),
-                        &pk_from_str_like(&mango_account_pk),
-                        &(pk_from_str_like(&mango_account_signer.pubkey())),
-                        &pk_from_str_like(&c.mango_cache_pk),
-                        &(pk_from_str_like(&c.perp_market_pk)),
-                        &c.perp_market.bids,
-                        &c.perp_market.asks,
-                        &c.perp_market.event_queue,
-                        None,
-                        &[],
-                        Side::Bid,
-                        c.price_quote_lots + offset - spread,
-                        c.order_base_lots,
-                        i64::MAX,
-                        1,
-                        mango::matching::OrderType::Limit,
-                        false,
-                        None,
-                        64,
-                        mango::matching::ExpiryType::Absolute,
+                let place_bid_ix: Instruction = serde_json::from_str(
+                    &serde_json::to_string(
+                        &place_perp_order2(
+                            &pk_from_str_like(&c.mango_program_pk),
+                            &pk_from_str_like(&c.mango_group_pk),
+                            &pk_from_str_like(&mango_account_pk),
+                            &(pk_from_str_like(&mango_account_signer.pubkey())),
+                            &pk_from_str_like(&c.mango_cache_pk),
+                            &(pk_from_str_like(&c.perp_market_pk)),
+                            &c.perp_market.bids,
+                            &c.perp_market.asks,
+                            &c.perp_market.event_queue,
+                            None,
+                            &[],
+                            Side::Bid,
+                            c.price_quote_lots + offset - spread,
+                            c.order_base_lots,
+                            i64::MAX,
+                            1,
+                            mango::matching::OrderType::Limit,
+                            false,
+                            None,
+                            64,
+                            mango::matching::ExpiryType::Absolute,
+                        )
+                        .unwrap(),
                     )
                     .unwrap(),
                 )
-                .unwrap(),
-            )
-            .unwrap();
+                .unwrap();
 
-            let place_ask_ix: Instruction = serde_json::from_str(
-                &serde_json::to_string(
-                    &place_perp_order2(
-                        &pk_from_str_like(&c.mango_program_pk),
-                        &pk_from_str_like(&c.mango_group_pk),
-                        &pk_from_str_like(&mango_account_pk),
-                        &(pk_from_str_like(&mango_account_signer.pubkey())),
-                        &pk_from_str_like(&c.mango_cache_pk),
-                        &(pk_from_str_like(&c.perp_market_pk)),
-                        &c.perp_market.bids,
-                        &c.perp_market.asks,
-                        &c.perp_market.event_queue,
-                        None,
-                        &[],
-                        Side::Ask,
-                        c.price_quote_lots + offset + spread,
-                        c.order_base_lots,
-                        i64::MAX,
-                        2,
-                        mango::matching::OrderType::Limit,
-                        false,
-                        None,
-                        64,
-                        mango::matching::ExpiryType::Absolute,
+                let place_ask_ix: Instruction = serde_json::from_str(
+                    &serde_json::to_string(
+                        &place_perp_order2(
+                            &pk_from_str_like(&c.mango_program_pk),
+                            &pk_from_str_like(&c.mango_group_pk),
+                            &pk_from_str_like(&mango_account_pk),
+                            &(pk_from_str_like(&mango_account_signer.pubkey())),
+                            &pk_from_str_like(&c.mango_cache_pk),
+                            &(pk_from_str_like(&c.perp_market_pk)),
+                            &c.perp_market.bids,
+                            &c.perp_market.asks,
+                            &c.perp_market.event_queue,
+                            None,
+                            &[],
+                            Side::Ask,
+                            c.price_quote_lots + offset + spread,
+                            c.order_base_lots,
+                            i64::MAX,
+                            2,
+                            mango::matching::OrderType::Limit,
+                            false,
+                            None,
+                            64,
+                            mango::matching::ExpiryType::Absolute,
+                        )
+                        .unwrap(),
                     )
                     .unwrap(),
                 )
-                .unwrap(),
-            )
-            .unwrap();
+                .unwrap();
 
-            let mut tx = Transaction::new_unsigned(Message::new(
-                &[cancel_ix, place_bid_ix, place_ask_ix],
-                Some(&mango_account_signer.pubkey()),
-            ));
+                let mut tx = Transaction::new_unsigned(Message::new(
+                    &[cancel_ix, place_bid_ix, place_ask_ix],
+                    Some(&mango_account_signer.pubkey()),
+                ));
+                transactions.push(tx);
+            }
 
             if let Ok(recent_blockhash) = blockhash.read() {
-                tx.sign(&[mango_account_signer], *recent_blockhash);
+                for tx in &mut transactions {
+                    tx.sign(&[mango_account_signer], *recent_blockhash);
+                }
             }
             let tpu_client = tpu_client_pool.get();
-            tpu_client.send_transaction(&tx);
-            let sent = tx_record_sx.send(TransactionSendRecord {
-                signature: tx.signatures[0],
-                sent_at: Utc::now(),
-                sent_slot: slot.load(Ordering::Acquire),
-                market_maker: mango_account_signer.pubkey(),
-                market: c.perp_market_pk,
-            });
-            if sent.is_err() {
-                println!(
-                    "sending error on channel : {}",
-                    sent.err().unwrap().to_string()
-                );
+            if tpu_client
+                .try_send_transaction_batch(&transactions)
+                .is_err()
+            {
+                error!("Sending batch failed");
+                continue;
             }
+
+            for tx in &transactions {
+                let sent = tx_record_sx.send(TransactionSendRecord {
+                    signature: tx.signatures[0],
+                    sent_at: Utc::now(),
+                    sent_slot: slot.load(Ordering::Acquire),
+                    market_maker: mango_account_signer.pubkey(),
+                    market: c.perp_market_pk,
+                });
+                if sent.is_err() {
+                    error!(
+                        "sending error on channel : {}",
+                        sent.err().unwrap().to_string()
+                    );
+                }
+            }
+            transactions.clear();
         }
     }
 }


### PR DESCRIPTION
Was 3k tps and became 40k:
<img width="1416" alt="Screenshot 2022-11-02 at 15 02 31" src="https://user-images.githubusercontent.com/687962/199524984-fc0cff06-17a3-449e-b45b-c0ce8d0265fe.png">

Changes to be made:
1. Add cli for batch size, if not specified don't use batched requests
2. Refactor send_mm_transactions by moving some common logic to separate methods/functions
3. Support batched and not batched requests (as requested by the tool author) in two different methods/functions