### PR TITLE
Send transactions in batches of configurable size

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,7 @@ pub struct Config {
     pub block_data_save_file: String,
     pub airdrop_accounts: bool,
     pub mango_cluster: String,
+    pub txs_batch_size: Option<usize>,
 }
 
 impl Default for Config {
@@ -37,6 +38,7 @@ impl Default for Config {
             block_data_save_file: String::new(),
             airdrop_accounts: false,
             mango_cluster: "testnet.0".to_string(),
+            txs_batch_size: None,
         }
     }
 }
@@ -168,6 +170,14 @@ pub fn build_args<'a, 'b>(version: &'b str) -> App<'a, 'b> {
                 .takes_value(true)
                 .help("Name of mango cluster from ids.json"),
         )
+        .arg(
+            Arg::with_name("batch-size")
+                .long("batch-size")
+                .value_name("UINT")
+                .takes_value(true)
+                .required(false)
+                .help("If specified, transactions are send in batches of specified size"),
+        )
 }
 
 /// Parses a clap `ArgMatches` structure into a `Config`
@@ -241,5 +251,8 @@ pub fn extract_args(matches: &ArgMatches) -> Config {
         Some(x) => x.to_string(),
         None => "testnet.0".to_string(),
     };
+    args.txs_batch_size = matches
+        .value_of("batch-size")
+        .map(|batch_size_str| batch_size_str.parse().expect("can't parse batch-size"));
     args
 }


### PR DESCRIPTION
Refactored version of https://github.com/godmodegalactus/mango_bencher/pull/2/files

Sending transactions in batches significantly increases tps:
<img width="1416" alt="Screenshot 2022-11-02 at 15 02 31" src="https://user-images.githubusercontent.com/687962/199524984-fc0cff06-17a3-449e-b45b-c0ce8d0265fe.png">
 
Please review commit by commit

Changes made:
1. Add cli for batch size, if not specified don't use batched requests
2. Refactor `send_mm_transactions` by moving  common logic for transaction creation to a separate methods/functions
3. Support batched and not batched requests (as requested by the tool author) in two different methods/functions